### PR TITLE
Docker-compose para colocar o serviço na network maratona-microsservi…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+
+  app:
+    build: .
+    container_name: drivers-app
+    ports:
+      - 8081:8081
+    networks:
+      - maratona-microsservico-order_app-network
+
+networks:
+  maratona-microsservico-order_app-network:
+    external: true


### PR DESCRIPTION
Docker-compose para colocar o serviço na network maratona-microsservico-order_app-network e ser enxergado como http://drivers-app:8081 no serviço de order.

Creio que pode facilitar pro pessoal não precisar descobrir o ip do docker e colocar no microserviço de orders.

Tive esta dificuldade e creio que desta forma pode facilitar.